### PR TITLE
Fix unit test issue in config advertised types

### DIFF
--- a/tests/config_an_test.py
+++ b/tests/config_an_test.py
@@ -77,7 +77,7 @@ class TestConfigInterface(object):
         assert 'duplicate' in result.output
         self.basic_check("advertised-types", ["Ethernet0", ""], ctx, operator.ne)
         result = self.basic_check("advertised-types", ["Ethernet16", "Invalid"], ctx, operator.ne)
-        assert "Setting RJ45 ports' advertised type is not supported" in result.output
+        assert "Setting RJ45 ports' advertised types is not supported" in result.output
 
     def basic_check(self, command_name, para_list, ctx, op=operator.eq, expect_result=0):
         runner = CliRunner()


### PR DESCRIPTION
Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

