### PR TITLE
Fix python exception due to type mismatch

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -79,7 +79,7 @@ def get_routing_stack():
 
     try:
         stdout = subprocess.check_output(command, shell=True, timeout=COMMAND_TIMEOUT)
-        result = stdout.rstrip('\n')
+        result = stdout.decode("utf-8").rstrip('\n')
     except Exception as err:
         click.echo('Failed to get routing stack: {}'.format(err), err=True)
 


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When issue command "show interfaces status", an error msg will print out: `Failed to get routing stack: a bytes-like object is required, not 'str'`


```
admin@sonic:# show in st
Failed to get routing stack: a bytes-like object is required, not 'str'
  Interface            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                                      Type    Asym PFC
-----------  ---------------  -------  -----  -----  -------  ------  ------  -------  ----------------------------------------  ----------
  Ethernet0          0,1,2,3      N/A   9100    N/A     etp1  routed    down       up                            SFP/SFP+/SFP28         N/A
  Ethernet4          4,5,6,7      N/A   9100    N/A     etp2  routed    down       up                           QSFP28 or later         N/A

```

This is exception is due to a type mismatch in function `get_routing_stack`, a `byte object` should be convert into `str` before call `rstrip()`

#### How I did it

convert the byte object to str by calling `decode()` ,  `stdout.decode("utf-8").rstrip('\n')`

#### How to verify it

Run 'show interfaces status' command to check the output

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

