### PR TITLE
Revert the logic to fetch presence status from error status for RJ45 port

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -432,34 +432,26 @@ class SFPShow(object):
 
                     self.output += '\n'
 
-    def convert_presence_info_to_cli_output_string(self, state_db, interface_name):
-        sfp_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface_name))
-        if not sfp_info_dict:
-            status_string = 'Not present'
-        elif sfp_info_dict.get('type') == RJ45_PORT_TYPE:
-            status = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_STATUS|{}'.format(interface_name))
-            status_string = status.get('error')
-            if status_string == 'N/A':
-                status_string = 'Present'
-        else:
-            status_string = 'Present'
-
-        return status_string
-
     @multi_asic_util.run_on_multi_asic
     def get_presence(self):
         port_table = []
 
         if self.intf_name is not None:
-            presence_str = self.convert_presence_info_to_cli_output_string(self.db, self.intf_name)
-            port_table.append((self.intf_name, presence_str))
+            presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(self.intf_name))
+            if presence:
+                port_table.append((self.intf_name, 'Present'))
+            else:
+                port_table.append((self.intf_name, 'Not present'))
         else:
             port_table_keys = self.db.keys(self.db.APPL_DB, "PORT_TABLE:*")
             for i in port_table_keys:
                 key = re.split(':', i, maxsplit=1)[-1].strip()
                 if key and key.startswith(front_panel_prefix()) and not key.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
-                    presence_str = self.convert_presence_info_to_cli_output_string(self.db, key)
-                    port_table.append((key, presence_str))
+                    presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(key))
+                    if presence:
+                        port_table.append((key, 'Present'))
+                    else:
+                        port_table.append((key, 'Not present'))
 
         self.table += port_table
 

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -661,13 +661,6 @@ def presence(port):
 
         logical_port_list = [port]
 
-    state_db = SonicV2Connector(host='127.0.0.1')
-    if state_db is not None:
-        state_db.connect(state_db.STATE_DB)
-    else:
-        click.echo("Failed to connect to STATE_DB")
-        return
-
     for logical_port_name in logical_port_list:
         ganged = False
         i = 1
@@ -683,19 +676,13 @@ def presence(port):
         for physical_port in physical_port_list:
             port_name = get_physical_port_name(logical_port_name, i, ganged)
 
-            if is_rj45_port_from_db(port_name, state_db):
-                status = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_STATUS|{}'.format(port_name))
-                status_string = status.get('error')
-                if status_string == 'N/A':
-                    status_string = 'Present'
-            else:
-                try:
-                    presence = platform_chassis.get_sfp(physical_port).get_presence()
-                except NotImplementedError:
-                    click.echo("This functionality is currently not implemented for this platform")
-                    sys.exit(ERROR_NOT_IMPLEMENTED)
+            try:
+                presence = platform_chassis.get_sfp(physical_port).get_presence()
+            except NotImplementedError:
+                click.echo("This functionality is currently not implemented for this platform")
+                sys.exit(ERROR_NOT_IMPLEMENTED)
 
-                status_string = "Present" if presence else "Not present"
+            status_string = "Present" if presence else "Not present"
             output_table.append([port_name, status_string])
 
             i += 1

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -150,8 +150,8 @@
         "error": "N/A"
     },
     "TRANSCEIVER_STATUS|Ethernet16": {
-        "status": "255",
-        "error": "Not present"
+        "status": "0",
+        "error": "N/A"
     },
     "TRANSCEIVER_STATUS|Ethernet28": {
         "status": "0",

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -350,8 +350,8 @@ Ethernet200  Not present
 
         result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["presence"], ["Ethernet16"])
         expected = """Port        Presence
-----------  -----------
-Ethernet16  Not present
+----------  ----------
+Ethernet16  Present
 """
         assert result.exit_code == 0
         assert result.output == expected
@@ -367,7 +367,7 @@ Ethernet28  Present
         result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["presence"], ["Ethernet36"])
         expected = """Port        Presence
 ----------  ----------
-Ethernet36  Unknown
+Ethernet36  Present
 """
         assert result.exit_code == 0
         assert result.output == expected

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -220,8 +220,8 @@ class TestSfputil(object):
         result = runner.invoke(sfputil.cli.commands['show'].commands['presence'], ["-p", "Ethernet16"])
         assert result.exit_code == 0
         expected_output = """Port        Presence
-----------  -----------
-Ethernet16  Not present
+----------  ----------
+Ethernet16  Present
 """
         assert result.output == expected_output
 
@@ -237,7 +237,7 @@ Ethernet28  Present
         assert result.exit_code == 0
         expected_output = """Port        Presence
 ----------  ----------
-Ethernet36  Unknown
+Ethernet36  Present
 """
         assert result.output == expected_output
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Revert the logic to fetch presence status from error status for RJ45 port

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

