### PR TITLE
[DO_NOT_MERGE_FOR_REVIEW_ONLY] Present status for RJ45 port

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -231,6 +231,10 @@ def display_invalid_intf_presence(intf_name):
 
 
 class SFPShow(object):
+    platform_chassis = None
+    platform_sfp = None
+    load_chassis_failed = False
+    platform_sfputil_loaded = False
 
     def __init__(self, intf_name, namespace_option, dump_dom=False):
         super(SFPShow, self).__init__()
@@ -431,6 +435,34 @@ class SFPShow(object):
                         self.intf_eeprom[interface] = "SFP EEPROM Not detected\n"
 
 
+    def is_rj45_port_from_api(self, port_name):
+        if not self.platform_chassis and not self.load_chassis_failed:
+            try:
+                import sonic_platform, sonic_platform_base
+                self.platform_chassis = sonic_platform.platform.Platform().get_chassis()
+                self.platform_sfp = sonic_platform_base.sfp_base.SfpBase
+            except Exception as e:
+                log.log_error("Failed to instantiate Chassis due to {}".format(repr(e)))
+                self.load_chassis_failed = True
+
+        if self.platform_chassis:
+            from utilities_common import platform_sfputil_helper
+            if not self.platform_sfputil_loaded:
+                platform_sfputil_helper.load_platform_sfputil()
+                platform_sfputil_helper.platform_sfputil_read_porttab_mappings()
+                self.platform_sfputil_loaded = True
+
+            physical_port = platform_sfputil_helper.logical_port_name_to_physical_port_list(port_name)[0]
+            try:
+                port_type = self.platform_chassis.get_port_or_cage_type(physical_port)
+            except NotImplementedError as e:
+                port_type = None
+
+            return port_type == self.platform_sfp.SFP_PORT_TYPE_BIT_RJ45
+
+        return False
+
+
     def convert_interface_sfp_presence_state_to_cli_output_string(self, state_db, interface_name):
         sfp_info_dict = state_db.get_all(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface_name))
         if sfp_info_dict:
@@ -439,7 +471,11 @@ class SFPShow(object):
             else:
                 output = 'Present'
         else:
-            output = 'Not present'
+            # We have to check whether it is an RJ45 port via calling platform API in case it is absent
+            if self.is_rj45_port_from_api(interface_name):
+                output = 'Link Down'
+            else:
+                output = 'Not present'
         return output
 
 

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -431,26 +431,32 @@ class SFPShow(object):
                         self.intf_eeprom[interface] = "SFP EEPROM Not detected\n"
 
 
+    def convert_interface_sfp_presence_state_to_cli_output_string(self, state_db, interface_name):
+        sfp_info_dict = state_db.get_all(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface_name))
+        if sfp_info_dict:
+            if sfp_info_dict['type'] == RJ45_PORT_TYPE:
+                output = 'Link Up'
+            else:
+                output = 'Present'
+        else:
+            output = 'Not present'
+        return output
+
+
     @multi_asic_util.run_on_multi_asic
     def get_presence(self):
         port_table = []
 
         if self.intf_name is not None:
-            presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(self.intf_name))
-            if presence:
-                port_table.append((self.intf_name, 'Present'))
-            else:
-                port_table.append((self.intf_name, 'Not present'))
+            presence_string = self.convert_interface_sfp_presence_state_to_cli_output_string(self.db, self.intf_name)
+            port_table.append((self.intf_name, presence_string))
         else:
             port_table_keys = self.db.keys(self.db.APPL_DB, "PORT_TABLE:*")
             for i in port_table_keys:
                 key = re.split(':', i, maxsplit=1)[-1].strip()
                 if key and key.startswith(front_panel_prefix()) and not key.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
-                    presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(key))
-                    if presence:
-                        port_table.append((key, 'Present'))
-                    else:
-                        port_table.append((key, 'Not present'))
+                    presence_string = self.convert_interface_sfp_presence_state_to_cli_output_string(self.db, key)
+                    port_table.append((key, presence_string))
 
         self.table += port_table
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
DO NOT MERGE. FOR REVIEW ONLY.

1. Update the present status for RJ45 ports
2. Use new platform API to check whether a port is RJ45 when it is absent

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

