### PR TITLE
Fix python SyntaxWarning for "is" with literals

### DIFF
--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -899,7 +899,7 @@ class ComponentUpdateProvider(PlatformDataProvider):
             if status_file is not None:
                 data = self.read_au_status_file_if_exists(FW_AU_STATUS_FILE_PATH)
                 if data is not None:
-                    if boot is "none" or boot in data:
+                    if boot == "none" or boot in data:
                         click.echo("Allow firmware auto-update with boot_type {} again".format(boot))
                         return True
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

