### PR TITLE
[Graceful Reboot] Check the watchdog supporting capability before arm the watchdog in the reboot scripts

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -11,6 +11,8 @@ PLATFORM_UPDATE_REBOOT_CAUSE="platform_update_reboot_cause"
 REBOOT_CAUSE_FILE="/host/reboot-cause/reboot-cause.txt"
 PLATFORM_REBOOT_PRE_CHECK="platform_reboot_pre_check"
 REBOOT_TIME=$(date)
+PLATFORMS_NOT_SUPPORT_180S_WD=("x86_64-mlnx_msn2100-r0" "x86_64-mlnx_msn2010-r0")
+IS_PLATFORM_SUPPORT_180S_WD=1
 
 # Reboot immediately if we run the kdump capture kernel
 VMCORE_FILE=/proc/vmcore
@@ -177,6 +179,19 @@ function check_conflict_boot_in_fw_update()
     fi
 }
 
+function is_platform_support_180s_wd()
+{
+    # Test whether the platform support 180s wathdog
+    for i in "${PLATFORMS_NOT_SUPPORT_180S_WD[@]}"
+    do
+        if [ "$i" == "${PLATFORM}" ] ; then
+            debug "Platform ${PLATFORM} doesn't support 180s watchdog"
+            IS_PLATFORM_SUPPORT_180S_WD=0
+            return
+        fi
+    done
+}
+
 function parse_options()
 {
     while getopts "h?v" opt; do
@@ -265,9 +280,13 @@ if [ -x ${DEVPATH}/${PLATFORM}/${PRE_REBOOT_HOOK} ]; then
     fi
 fi
 
-if [ -x ${WATCHDOG_UTIL} ]; then
+is_platform_support_180s_wd
+
+if [[ -x ${WATCHDOG_UTIL} && "${IS_PLATFORM_SUPPORT_180S_WD}" == 1 ]]; then
     debug "Enabling the Watchdog before reboot"
     ${WATCHDOG_UTIL} arm
+else
+    debug "Skip enabling the watchdog"
 fi
 
 if [ -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
In the current implementation, the reboot script will arm the watchdog with 180s timeout periods, not all the platforms can support a such long watchdog timeout period. 

For example, Nvidia "x86_64-mlnx_msn2100-r0" and "x86_64-mlnx_msn2010-r0" platforms can only support 32s timeout periods.  When use "watchdogutil" to arm WD on them with 180s periods, the WD timeout will only be set to the max value of 32s.  Within these timeout periods, the platforms even can not finish shutdown, so each time during the reboot WD will always kick in and interrupt the graceful shutdown. it will also cause a confusing reboot cause(triggered by the watchdog). On this kind of platform, watchdog should not be armed to avoid issues.


#### How I did it

Add a list of platforms that do not support long watchdog timeout periods (180s), for these platforms the reboot command will skip the arm watchdog step.

#### How to verify it

perform reboot on all the platforms, watchdog can be armed or skipped accordingly after performing the reboot command.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

